### PR TITLE
PHP8 Updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "acmephp/ssl": "^2.0",
         "guzzlehttp/guzzle": "^6.0|^7.0",
         "guzzlehttp/psr7": "^1.0",
-        "lcobucci/jwt": "^3.3",
+        "lcobucci/jwt": "^3.3|^4.0",
         "psr/http-message": "^1.0",
         "psr/log": "^1.0",
         "webmozart/assert": "^1.0"


### PR DESCRIPTION
# WIP: PHP8 Support

## Issue 1
`lcobucci/jwt:3.3` doesn't support PHP8, but `4.0` version does

# Notes
I still need to actually run unit tests on this.
